### PR TITLE
composer: allow PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "aura/cli": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi, 
I'm trying to composer install Rector book, but fail with PHP 8 here.